### PR TITLE
feat(export): unify users by email and generate enriched CSV

### DIFF
--- a/src/main/java/com/bemobi/aicontrol/service/UnifiedUser.java
+++ b/src/main/java/com/bemobi/aicontrol/service/UnifiedUser.java
@@ -1,0 +1,24 @@
+package com.bemobi.aicontrol.service;
+
+/**
+ * Record imutável representando um usuário unificado entre múltiplas ferramentas de IA.
+ *
+ * Cada instância consolida dados de até 3 ferramentas (Claude, Copilot, Cursor)
+ * em uma única linha, com flags de presença e informações de atividade por ferramenta.
+ */
+public record UnifiedUser(
+        String email,
+        String name,
+        int toolsCount,
+        boolean usesClaude,
+        boolean usesCopilot,
+        boolean usesCursor,
+        String claudeLastActivity,
+        String copilotLastActivity,
+        String cursorLastActivity,
+        String claudeStatus,
+        String copilotStatus,
+        String cursorStatus,
+        String emailType
+) {
+}

--- a/src/main/java/com/bemobi/aicontrol/service/UserUnificationService.java
+++ b/src/main/java/com/bemobi/aicontrol/service/UserUnificationService.java
@@ -1,0 +1,217 @@
+package com.bemobi.aicontrol.service;
+
+import com.bemobi.aicontrol.integration.common.UserData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service responsável por unificar dados de usuários coletados de múltiplas ferramentas de IA.
+ *
+ * Agrupa por email (case-insensitive) e produz uma lista de {@link UnifiedUser}
+ * com uma entrada por usuário, contendo flags de presença por ferramenta.
+ */
+@Service
+public class UserUnificationService {
+
+    private static final Logger log = LoggerFactory.getLogger(UserUnificationService.class);
+    private static final DateTimeFormatter CSV_DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+    private static final String NO_GITHUB_USER_PREFIX = "[sem-usr-github]";
+
+    /**
+     * Unifica dados de usuários de múltiplas ferramentas em uma lista de usuários únicos.
+     *
+     * @param dataByTool Map com nome da ferramenta como chave e lista de UserData como valor
+     * @return Lista de UnifiedUser ordenada por toolsCount DESC, email ASC
+     */
+    public List<UnifiedUser> unify(Map<String, List<UserData>> dataByTool) {
+        if (dataByTool == null || dataByTool.isEmpty()) {
+            return List.of();
+        }
+
+        Map<String, UserBuilder> buildersByKey = new LinkedHashMap<>();
+
+        for (Map.Entry<String, List<UserData>> entry : dataByTool.entrySet()) {
+            String toolName = entry.getKey();
+            List<UserData> users = entry.getValue();
+
+            for (UserData user : users) {
+                String key = resolveKey(user, toolName);
+                UserBuilder builder = buildersByKey.computeIfAbsent(key, k -> new UserBuilder(resolveEmail(user)));
+                builder.applyTool(toolName, user);
+            }
+        }
+
+        List<UnifiedUser> result = new ArrayList<>();
+        for (UserBuilder builder : buildersByKey.values()) {
+            result.add(builder.build());
+        }
+
+        result.sort(Comparator
+                .comparingInt(UnifiedUser::toolsCount).reversed()
+                .thenComparing(UnifiedUser::email, String.CASE_INSENSITIVE_ORDER));
+
+        log.info("Unified {} tool entries into {} unique users", countTotalEntries(dataByTool), result.size());
+        return result;
+    }
+
+    /**
+     * Gera um resumo textual da coleta de dados.
+     *
+     * @param users     Lista de usuários unificados
+     * @param rawData   Dados brutos por ferramenta
+     * @return Texto formatado com o resumo
+     */
+    public String buildSummary(List<UnifiedUser> users, Map<String, List<UserData>> rawData) {
+        int total = users.size();
+        long claudeCount = countByTool(rawData, "claude");
+        long copilotCount = countByTool(rawData, "github-copilot");
+        long cursorCount = countByTool(rawData, "cursor");
+        long multiTool = users.stream().filter(u -> u.toolsCount() >= 2).count();
+        long allThree = users.stream().filter(u -> u.toolsCount() == 3).count();
+        long noEmail = users.stream().filter(u -> u.email().startsWith(NO_GITHUB_USER_PREFIX)).count();
+
+        String multiToolPct = total > 0 ? String.valueOf(Math.round((double) multiTool / total * 100)) : "0";
+        String allThreePct = total > 0 ? String.valueOf(Math.round((double) allThree / total * 100)) : "0";
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("=== Resumo da Coleta ===\n");
+        sb.append(String.format("Total de usuários únicos: %d%n", total));
+        sb.append(String.format("Claude Code: %d ativos%n", claudeCount));
+        sb.append(String.format("GitHub Copilot: %d ativos%n", copilotCount));
+        sb.append(String.format("Cursor: %d ativos%n", cursorCount));
+        sb.append(String.format("Usam 2+ ferramentas: %d (%s%%)%n", multiTool, multiToolPct));
+        sb.append(String.format("Usam todas (3): %d (%s%%)%n", allThree, allThreePct));
+        sb.append(String.format("Sem email resolvido: %d", noEmail));
+
+        return sb.toString();
+    }
+
+    private String resolveKey(UserData user, String toolName) {
+        String email = user.email() != null ? user.email() : "";
+        if (email.startsWith(NO_GITHUB_USER_PREFIX)) {
+            String login = extractGithubLogin(user);
+            return NO_GITHUB_USER_PREFIX + "#" + login;
+        }
+        return email.toLowerCase().trim();
+    }
+
+    private String resolveEmail(UserData user) {
+        return user.email() != null ? user.email() : "";
+    }
+
+    private String extractGithubLogin(UserData user) {
+        String email = user.email() != null ? user.email() : "";
+        if (email.startsWith(NO_GITHUB_USER_PREFIX)) {
+            // O email pode conter informação do login após o prefixo
+            // Formato esperado: [sem-usr-github] ou o name pode ser o login
+            String name = user.name() != null ? user.name() : "";
+            return name.isEmpty() ? email : name;
+        }
+        return email;
+    }
+
+    private long countByTool(Map<String, List<UserData>> rawData, String toolName) {
+        List<UserData> users = rawData.get(toolName);
+        return users != null ? users.size() : 0;
+    }
+
+    private int countTotalEntries(Map<String, List<UserData>> dataByTool) {
+        return dataByTool.values().stream().mapToInt(List::size).sum();
+    }
+
+    /**
+     * Builder interno para acumular dados de um usuário ao longo de múltiplas ferramentas.
+     */
+    private static class UserBuilder {
+        private final String email;
+        private String name;
+        private boolean usesClaude;
+        private boolean usesCopilot;
+        private boolean usesCursor;
+        private String claudeLastActivity = "";
+        private String copilotLastActivity = "";
+        private String cursorLastActivity = "";
+        private String claudeStatus = "";
+        private String copilotStatus = "";
+        private String cursorStatus = "";
+        private String emailType = "";
+
+        // Prioridade de nome: github-copilot > claude > cursor
+        private int namePriority = -1;
+
+        UserBuilder(String email) {
+            this.email = email;
+        }
+
+        void applyTool(String toolName, UserData user) {
+            String lastActivity = user.lastActivityAt() != null
+                    ? user.lastActivityAt().format(CSV_DATETIME_FORMATTER)
+                    : "";
+            String status = user.status() != null ? user.status() : "";
+
+            switch (toolName) {
+                case "claude" -> {
+                    usesClaude = true;
+                    claudeLastActivity = lastActivity;
+                    claudeStatus = status;
+                    applyName(user.name(), 1); // prioridade média
+                }
+                case "github-copilot" -> {
+                    usesCopilot = true;
+                    copilotLastActivity = lastActivity;
+                    copilotStatus = status;
+                    applyName(user.name(), 2); // prioridade alta
+                }
+                case "cursor" -> {
+                    usesCursor = true;
+                    cursorLastActivity = lastActivity;
+                    cursorStatus = status;
+                    applyName(user.name(), 0); // prioridade baixa
+                }
+                default -> log.warn("Unknown tool: {}", toolName);
+            }
+
+            // Captura email_type do additionalMetrics
+            if (user.additionalMetrics() != null && user.additionalMetrics().containsKey("email_type")) {
+                String type = user.additionalMetrics().get("email_type").toString();
+                if (!type.isEmpty()) {
+                    emailType = type;
+                }
+            }
+        }
+
+        private void applyName(String candidateName, int priority) {
+            if (candidateName != null && !candidateName.isEmpty() && priority > namePriority) {
+                this.name = candidateName;
+                this.namePriority = priority;
+            }
+        }
+
+        UnifiedUser build() {
+            int toolsCount = (usesClaude ? 1 : 0) + (usesCopilot ? 1 : 0) + (usesCursor ? 1 : 0);
+            return new UnifiedUser(
+                    email,
+                    name != null ? name : "",
+                    toolsCount,
+                    usesClaude,
+                    usesCopilot,
+                    usesCursor,
+                    claudeLastActivity,
+                    copilotLastActivity,
+                    cursorLastActivity,
+                    claudeStatus,
+                    copilotStatus,
+                    cursorStatus,
+                    emailType
+            );
+        }
+    }
+}

--- a/src/test/java/com/bemobi/aicontrol/service/CsvExportServiceTest.java
+++ b/src/test/java/com/bemobi/aicontrol/service/CsvExportServiceTest.java
@@ -252,6 +252,49 @@ class CsvExportServiceTest {
         assertThat(lines).hasSize(11); // Header + 10 users
     }
 
+    @Test
+    void testExportToUnifiedCsv_CorrectHeaders() throws IOException {
+        // Arrange
+        List<UnifiedUser> users = List.of(
+                new UnifiedUser("user@example.com", "User", 2, true, true, false,
+                        "2026-02-05T14:30:00", "2026-02-06T10:00:00", "",
+                        "active", "active", "", "corporate")
+        );
+
+        // Act
+        Path csvFile = service.exportToUnifiedCsv(users);
+
+        // Assert
+        assertThat(csvFile).exists();
+        assertThat(csvFile.getFileName().toString()).startsWith("users-unified-");
+        assertThat(csvFile.getFileName().toString()).endsWith(".csv");
+
+        List<String> lines = Files.readAllLines(csvFile);
+        assertThat(lines).hasSize(2); // Header + 1 user
+        assertThat(lines.get(0)).isEqualTo(
+                "email,name,tools_count,uses_claude,uses_copilot,uses_cursor,"
+                        + "claude_last_activity,copilot_last_activity,cursor_last_activity,"
+                        + "claude_status,copilot_status,cursor_status,email_type"
+        );
+    }
+
+    @Test
+    void testExportToUnifiedCsv_BooleanValues() throws IOException {
+        // Arrange
+        List<UnifiedUser> users = List.of(
+                new UnifiedUser("user@example.com", "User", 2, true, false, true,
+                        "", "", "",
+                        "", "", "", "")
+        );
+
+        // Act
+        Path csvFile = service.exportToUnifiedCsv(users);
+
+        // Assert
+        List<String> lines = Files.readAllLines(csvFile);
+        assertThat(lines.get(1)).contains("true,false,true");
+    }
+
     private UserData createUserData(String email, String name, String status) {
         return new UserData(email, name, status, LocalDateTime.now(), null, null);
     }

--- a/src/test/java/com/bemobi/aicontrol/service/UserUnificationServiceTest.java
+++ b/src/test/java/com/bemobi/aicontrol/service/UserUnificationServiceTest.java
@@ -1,0 +1,245 @@
+package com.bemobi.aicontrol.service;
+
+import com.bemobi.aicontrol.integration.common.UserData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserUnificationServiceTest {
+
+    private UserUnificationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new UserUnificationService();
+    }
+
+    @Test
+    void unify_singleToolUser_returnsToolsCountOne() {
+        Map<String, List<UserData>> data = new HashMap<>();
+        data.put("claude", List.of(
+                createUserData("joao@emp.com", "Joao", "active")
+        ));
+
+        List<UnifiedUser> result = service.unify(data);
+
+        assertThat(result).hasSize(1);
+        UnifiedUser user = result.get(0);
+        assertThat(user.toolsCount()).isEqualTo(1);
+        assertThat(user.usesClaude()).isTrue();
+        assertThat(user.usesCopilot()).isFalse();
+        assertThat(user.usesCursor()).isFalse();
+        assertThat(user.email()).isEqualTo("joao@emp.com");
+        assertThat(user.name()).isEqualTo("Joao");
+    }
+
+    @Test
+    void unify_twoToolsSameEmail_returnsToolsCountTwo() {
+        Map<String, List<UserData>> data = new HashMap<>();
+        data.put("claude", List.of(
+                createUserData("joao@emp.com", "Joao Claude", "active")
+        ));
+        data.put("github-copilot", List.of(
+                createUserData("joao@emp.com", "Joao GitHub", "active")
+        ));
+
+        List<UnifiedUser> result = service.unify(data);
+
+        assertThat(result).hasSize(1);
+        UnifiedUser user = result.get(0);
+        assertThat(user.toolsCount()).isEqualTo(2);
+        assertThat(user.usesClaude()).isTrue();
+        assertThat(user.usesCopilot()).isTrue();
+        assertThat(user.usesCursor()).isFalse();
+    }
+
+    @Test
+    void unify_threeToolsSameEmail_returnsToolsCountThree() {
+        Map<String, List<UserData>> data = new HashMap<>();
+        data.put("claude", List.of(
+                createUserData("joao@emp.com", "Joao", "active")
+        ));
+        data.put("github-copilot", List.of(
+                createUserData("joao@emp.com", "Joao", "active")
+        ));
+        data.put("cursor", List.of(
+                createUserData("joao@emp.com", "Joao", "active")
+        ));
+
+        List<UnifiedUser> result = service.unify(data);
+
+        assertThat(result).hasSize(1);
+        UnifiedUser user = result.get(0);
+        assertThat(user.toolsCount()).isEqualTo(3);
+        assertThat(user.usesClaude()).isTrue();
+        assertThat(user.usesCopilot()).isTrue();
+        assertThat(user.usesCursor()).isTrue();
+    }
+
+    @Test
+    void unify_caseInsensitiveEmail_unifiesSameUser() {
+        Map<String, List<UserData>> data = new HashMap<>();
+        data.put("claude", List.of(
+                createUserData("Joao@Emp.com", "Joao", "active")
+        ));
+        data.put("github-copilot", List.of(
+                createUserData("joao@emp.com", "Joao", "active")
+        ));
+
+        List<UnifiedUser> result = service.unify(data);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).toolsCount()).isEqualTo(2);
+    }
+
+    @Test
+    void unify_semUsrGithub_doesNotUnifyBetweenEachOther() {
+        Map<String, List<UserData>> data = new HashMap<>();
+        data.put("github-copilot", List.of(
+                createUserData("[sem-usr-github]", "loginA", "active"),
+                createUserData("[sem-usr-github]", "loginB", "active")
+        ));
+
+        List<UnifiedUser> result = service.unify(data);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).allMatch(u -> u.toolsCount() == 1);
+    }
+
+    @Test
+    void unify_namePriority_githubOverClaudeOverCursor() {
+        Map<String, List<UserData>> data = new HashMap<>();
+        data.put("cursor", List.of(
+                createUserData("joao@emp.com", "Joao Cursor", "active")
+        ));
+        data.put("claude", List.of(
+                createUserData("joao@emp.com", "Joao Claude", "active")
+        ));
+        data.put("github-copilot", List.of(
+                createUserData("joao@emp.com", "Joao GitHub", "active")
+        ));
+
+        List<UnifiedUser> result = service.unify(data);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).name()).isEqualTo("Joao GitHub");
+    }
+
+    @Test
+    void unify_namePriority_claudeOverCursor() {
+        Map<String, List<UserData>> data = new HashMap<>();
+        data.put("cursor", List.of(
+                createUserData("joao@emp.com", "Joao Cursor", "active")
+        ));
+        data.put("claude", List.of(
+                createUserData("joao@emp.com", "Joao Claude", "active")
+        ));
+
+        List<UnifiedUser> result = service.unify(data);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).name()).isEqualTo("Joao Claude");
+    }
+
+    @Test
+    void unify_sortsByToolsCountDescThenEmailAsc() {
+        Map<String, List<UserData>> data = new HashMap<>();
+        data.put("claude", List.of(
+                createUserData("alice@emp.com", "Alice", "active"),
+                createUserData("bob@emp.com", "Bob", "active"),
+                createUserData("charlie@emp.com", "Charlie", "active")
+        ));
+        data.put("github-copilot", List.of(
+                createUserData("charlie@emp.com", "Charlie", "active"),
+                createUserData("bob@emp.com", "Bob", "active")
+        ));
+
+        List<UnifiedUser> result = service.unify(data);
+
+        assertThat(result).hasSize(3);
+        // bob e charlie têm toolsCount=2, alice tem 1
+        assertThat(result.get(0).email()).isEqualTo("bob@emp.com");
+        assertThat(result.get(0).toolsCount()).isEqualTo(2);
+        assertThat(result.get(1).email()).isEqualTo("charlie@emp.com");
+        assertThat(result.get(1).toolsCount()).isEqualTo(2);
+        assertThat(result.get(2).email()).isEqualTo("alice@emp.com");
+        assertThat(result.get(2).toolsCount()).isEqualTo(1);
+    }
+
+    @Test
+    void unify_emptyMap_returnsEmptyList() {
+        List<UnifiedUser> result = service.unify(Map.of());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void unify_nullMap_returnsEmptyList() {
+        List<UnifiedUser> result = service.unify(null);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void buildSummary_returnsCorrectFormat() {
+        Map<String, List<UserData>> rawData = new HashMap<>();
+        rawData.put("claude", List.of(
+                createUserData("a@e.com", "A", "active"),
+                createUserData("b@e.com", "B", "active")
+        ));
+        rawData.put("github-copilot", List.of(
+                createUserData("a@e.com", "A", "active"),
+                createUserData("c@e.com", "C", "active")
+        ));
+        rawData.put("cursor", List.of(
+                createUserData("a@e.com", "A", "active")
+        ));
+
+        List<UnifiedUser> unified = service.unify(rawData);
+        String summary = service.buildSummary(unified, rawData);
+
+        assertThat(summary).contains("=== Resumo da Coleta ===");
+        assertThat(summary).contains("Total de usuários únicos: 3");
+        assertThat(summary).contains("Claude Code: 2 ativos");
+        assertThat(summary).contains("GitHub Copilot: 2 ativos");
+        assertThat(summary).contains("Cursor: 1 ativos");
+        assertThat(summary).contains("Usam 2+ ferramentas: 1");
+        assertThat(summary).contains("Usam todas (3): 1");
+        assertThat(summary).contains("Sem email resolvido: 0");
+    }
+
+    @Test
+    void unify_preservesLastActivityAndStatus() {
+        LocalDateTime claudeActivity = LocalDateTime.of(2026, 2, 5, 14, 30, 0);
+        LocalDateTime copilotActivity = LocalDateTime.of(2026, 2, 6, 10, 0, 0);
+
+        Map<String, List<UserData>> data = new HashMap<>();
+        data.put("claude", List.of(
+                new UserData("joao@emp.com", "Joao", "active", claudeActivity, null, null)
+        ));
+        data.put("github-copilot", List.of(
+                new UserData("joao@emp.com", "Joao", "inactive", copilotActivity, null, null)
+        ));
+
+        List<UnifiedUser> result = service.unify(data);
+
+        assertThat(result).hasSize(1);
+        UnifiedUser user = result.get(0);
+        assertThat(user.claudeLastActivity()).isEqualTo("2026-02-05T14:30:00");
+        assertThat(user.copilotLastActivity()).isEqualTo("2026-02-06T10:00:00");
+        assertThat(user.cursorLastActivity()).isEmpty();
+        assertThat(user.claudeStatus()).isEqualTo("active");
+        assertThat(user.copilotStatus()).isEqualTo("inactive");
+        assertThat(user.cursorStatus()).isEmpty();
+    }
+
+    private UserData createUserData(String email, String name, String status) {
+        return new UserData(email, name, status, LocalDateTime.now(), null, null);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `UserUnificationService` that merges user data across Claude, Copilot and Cursor into a single row per user, keyed by email (case-insensitive)
- Add `exportToUnifiedCsv()` to `CsvExportService`, generating a `users-unified-{timestamp}.csv` with per-tool flags, activity dates, statuses and email type
- Log a terminal summary with overlap statistics after every collection run

Closes #7

## Test plan
- [x] `UserUnificationServiceTest` — 12 tests covering: single/multi-tool unification, case-insensitive email, `[sem-usr-github]` non-unification, name priority (GitHub > Claude > Cursor), sort order, summary format, edge cases
- [x] `CsvExportServiceTest` — 2 new tests for unified CSV headers and boolean values
- [x] All 107 tests pass (`mvn test`)
- [ ] Manual review: run the app and verify the unified CSV output and terminal summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)