### PR TITLE
refactor(UserData): populate rawJson and enforce immutability (#15, #16)

### DIFF
--- a/src/main/java/com/bemobi/aicontrol/integration/common/UserData.java
+++ b/src/main/java/com/bemobi/aicontrol/integration/common/UserData.java
@@ -1,12 +1,18 @@
 package com.bemobi.aicontrol.integration.common;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
  * DTO base para dados de usuário coletados de ferramentas de IA.
  *
- * Este DTO normaliza informações de diferentes plataformas em um formato comum.
+ * <p>Este DTO normaliza informações de diferentes plataformas em um formato comum.</p>
+ *
+ * @param additionalMetrics métricas específicas por ferramenta — imutável após construção.
+ *                          Chaves variam conforme a origem (ex: "role", "email_type", "github_login").
+ * @param rawJson JSON bruto da resposta da API de origem, para debug/auditoria.
  */
 public record UserData(
         String email,
@@ -17,8 +23,8 @@ public record UserData(
         String rawJson
 ) {
     public UserData {
-        if (additionalMetrics == null) {
-            additionalMetrics = Map.of();
-        }
+        additionalMetrics = additionalMetrics == null
+                ? Map.of()
+                : Collections.unmodifiableMap(new HashMap<>(additionalMetrics));
     }
 }

--- a/src/main/java/com/bemobi/aicontrol/integration/cursor/CursorApiClient.java
+++ b/src/main/java/com/bemobi/aicontrol/integration/cursor/CursorApiClient.java
@@ -6,6 +6,8 @@ import com.bemobi.aicontrol.integration.common.ConnectionTestResult;
 import com.bemobi.aicontrol.integration.common.UserData;
 import com.bemobi.aicontrol.integration.cursor.dto.CursorTeamMember;
 import com.bemobi.aicontrol.integration.cursor.dto.CursorTeamMembersResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -41,10 +43,13 @@ public class CursorApiClient implements ToolApiClient {
 
     private final WebClient webClient;
     private final CursorApiProperties properties;
+    private final ObjectMapper objectMapper;
 
     public CursorApiClient(WebClient.Builder webClientBuilder,
-                          CursorApiProperties properties) {
+                          CursorApiProperties properties,
+                          ObjectMapper objectMapper) {
         this.properties = properties;
+        this.objectMapper = objectMapper;
 
         // Only create WebClient if properties are configured
         String baseUrl = properties.getBaseUrl() != null ? properties.getBaseUrl() : "https://api.cursor.com";
@@ -129,8 +134,17 @@ public class CursorApiClient implements ToolApiClient {
                 "active",
                 null,
                 metrics,
-                null
+                toRawJson(member)
         );
+    }
+
+    private String toRawJson(Object dto) {
+        try {
+            return objectMapper.writeValueAsString(dto);
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to serialize rawJson", e);
+            return null;
+        }
     }
 
     private Mono<? extends Throwable> handle4xxError(ClientResponse response) {

--- a/src/main/java/com/bemobi/aicontrol/integration/cursor/CursorCsvClient.java
+++ b/src/main/java/com/bemobi/aicontrol/integration/cursor/CursorCsvClient.java
@@ -4,6 +4,8 @@ import com.bemobi.aicontrol.integration.ToolApiClient;
 import com.bemobi.aicontrol.integration.common.ApiClientException;
 import com.bemobi.aicontrol.integration.common.ConnectionTestResult;
 import com.bemobi.aicontrol.integration.common.UserData;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -39,9 +41,12 @@ public class CursorCsvClient implements ToolApiClient {
     private static final Logger log = LoggerFactory.getLogger(CursorCsvClient.class);
 
     private final CursorApiProperties properties;
+    private final ObjectMapper objectMapper;
 
-    public CursorCsvClient(CursorApiProperties properties) {
+    public CursorCsvClient(CursorApiProperties properties,
+                           ObjectMapper objectMapper) {
         this.properties = properties;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -196,7 +201,17 @@ public class CursorCsvClient implements ToolApiClient {
                 resolvedStatus,
                 lastActivityAt,
                 metrics,
-                null
+                csvRecordToJson(record)
         );
+    }
+
+    private String csvRecordToJson(CSVRecord record) {
+        try {
+            Map<String, String> map = record.toMap();
+            return objectMapper.writeValueAsString(map);
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to serialize CSV record to JSON", e);
+            return null;
+        }
     }
 }

--- a/src/test/java/com/bemobi/aicontrol/integration/claude/ClaudeApiClientTest.java
+++ b/src/test/java/com/bemobi/aicontrol/integration/claude/ClaudeApiClientTest.java
@@ -5,6 +5,8 @@ import com.bemobi.aicontrol.integration.claude.dto.ClaudeMembersResponse;
 import com.bemobi.aicontrol.integration.common.ApiClientException;
 import com.bemobi.aicontrol.integration.common.ConnectionTestResult;
 import com.bemobi.aicontrol.integration.common.UserData;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -61,7 +63,9 @@ class ClaudeApiClientTest {
         when(webClientBuilder.defaultHeader(anyString(), anyString())).thenReturn(webClientBuilder);
         when(webClientBuilder.build()).thenReturn(webClient);
 
-        client = new ClaudeApiClient(webClientBuilder, properties);
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        client = new ClaudeApiClient(webClientBuilder, properties, objectMapper);
     }
 
     @Test
@@ -113,6 +117,9 @@ class ClaudeApiClientTest {
         assertNotNull(userData.lastActivityAt());
         assertEquals("member", userData.additionalMetrics().get("role"));
         assertEquals("user_123", userData.additionalMetrics().get("member_id"));
+        assertNotNull(userData.rawJson());
+        assertTrue(userData.rawJson().contains("test@example.com"));
+        assertTrue(userData.rawJson().contains("user_123"));
     }
 
     @Test

--- a/src/test/java/com/bemobi/aicontrol/integration/common/UserDataTest.java
+++ b/src/test/java/com/bemobi/aicontrol/integration/common/UserDataTest.java
@@ -56,6 +56,25 @@ class UserDataTest {
     }
 
     @Test
+    void testAdditionalMetricsIsImmutableWhenProvided() {
+        Map<String, Object> metrics = new HashMap<>();
+        metrics.put("role", "admin");
+
+        UserData userData = new UserData(null, null, null, null, metrics, null);
+
+        assertThrows(UnsupportedOperationException.class, () ->
+                userData.additionalMetrics().put("new_key", "value"));
+    }
+
+    @Test
+    void testAdditionalMetricsIsImmutableWhenNull() {
+        UserData userData = new UserData(null, null, null, null, null, null);
+
+        assertThrows(UnsupportedOperationException.class, () ->
+                userData.additionalMetrics().put("key", "value"));
+    }
+
+    @Test
     void testToString() {
         UserData userData = new UserData("test@example.com", "Test User", "active", null, null, null);
 

--- a/src/test/java/com/bemobi/aicontrol/integration/cursor/CursorApiClientTest.java
+++ b/src/test/java/com/bemobi/aicontrol/integration/cursor/CursorApiClientTest.java
@@ -5,6 +5,7 @@ import com.bemobi.aicontrol.integration.common.ConnectionTestResult;
 import com.bemobi.aicontrol.integration.common.UserData;
 import com.bemobi.aicontrol.integration.cursor.dto.CursorTeamMember;
 import com.bemobi.aicontrol.integration.cursor.dto.CursorTeamMembersResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,7 +60,8 @@ class CursorApiClientTest {
         when(webClientBuilder.defaultHeader(anyString(), anyString())).thenReturn(webClientBuilder);
         when(webClientBuilder.build()).thenReturn(webClient);
 
-        client = new CursorApiClient(webClientBuilder, properties);
+        ObjectMapper objectMapper = new ObjectMapper();
+        client = new CursorApiClient(webClientBuilder, properties, objectMapper);
     }
 
     @Test
@@ -103,6 +105,9 @@ class CursorApiClientTest {
         assertEquals("active", userData.status());
         assertEquals("admin", userData.additionalMetrics().get("role"));
         assertEquals("user_123", userData.additionalMetrics().get("user_id"));
+        assertNotNull(userData.rawJson());
+        assertTrue(userData.rawJson().contains("test@example.com"));
+        assertTrue(userData.rawJson().contains("user_123"));
     }
 
     @Test

--- a/src/test/java/com/bemobi/aicontrol/integration/cursor/CursorCsvClientTest.java
+++ b/src/test/java/com/bemobi/aicontrol/integration/cursor/CursorCsvClientTest.java
@@ -3,6 +3,7 @@ package com.bemobi.aicontrol.integration.cursor;
 import com.bemobi.aicontrol.integration.common.ApiClientException;
 import com.bemobi.aicontrol.integration.common.ConnectionTestResult;
 import com.bemobi.aicontrol.integration.common.UserData;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,7 +38,8 @@ class CursorCsvClientTest {
     void setUp() {
         when(properties.isEnabled()).thenReturn(true);
 
-        client = new CursorCsvClient(properties);
+        ObjectMapper objectMapper = new ObjectMapper();
+        client = new CursorCsvClient(properties, objectMapper);
     }
 
     @Test
@@ -92,6 +94,11 @@ class CursorCsvClientTest {
         assertEquals("user2@example.com", user2.email());
         assertEquals("User Two", user2.name());
         assertEquals("inactive", user2.status());
+
+        // Verify rawJson contains CSV data as JSON
+        assertNotNull(user1.rawJson());
+        assertTrue(user1.rawJson().contains("test@example.com"));
+        assertTrue(user1.rawJson().contains("Test User"));
     }
 
     @Test

--- a/src/test/java/com/bemobi/aicontrol/integration/github/GitHubCopilotApiClientTest.java
+++ b/src/test/java/com/bemobi/aicontrol/integration/github/GitHubCopilotApiClientTest.java
@@ -7,6 +7,8 @@ import com.bemobi.aicontrol.integration.github.dto.GitHubCopilotSeat;
 import com.bemobi.aicontrol.integration.github.dto.GitHubCopilotSeatsResponse;
 import com.bemobi.aicontrol.integration.github.dto.GitHubUser;
 import com.bemobi.aicontrol.integration.google.GoogleWorkspaceClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -68,8 +70,10 @@ class GitHubCopilotApiClientTest {
         when(webClientBuilder.defaultHeader(anyString(), anyString())).thenReturn(webClientBuilder);
         when(webClientBuilder.build()).thenReturn(webClient);
 
-        client = new GitHubCopilotApiClient(webClientBuilder, properties, workspaceClient);
-        clientWithoutWorkspace = new GitHubCopilotApiClient(webClientBuilder, properties, null);
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        client = new GitHubCopilotApiClient(webClientBuilder, properties, workspaceClient, objectMapper);
+        clientWithoutWorkspace = new GitHubCopilotApiClient(webClientBuilder, properties, null, objectMapper);
     }
 
     @Test
@@ -128,6 +132,9 @@ class GitHubCopilotApiClientTest {
         assertEquals("testuser", userData.additionalMetrics().get("github_login"));
         assertEquals(123L, userData.additionalMetrics().get("github_id"));
         assertEquals("workspace", userData.additionalMetrics().get("email_type"));
+        assertNotNull(userData.rawJson());
+        assertTrue(userData.rawJson().contains("vscode"));
+        assertTrue(userData.rawJson().contains("testuser"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- **#15**: Popula o campo `rawJson` com o JSON bruto do DTO de origem em todos os 4 API clients (Claude, GitHub Copilot, Cursor API, Cursor CSV) via injeção de `ObjectMapper`
- **#16**: Garante imutabilidade de `additionalMetrics` com `Collections.unmodifiableMap` no compact constructor do record (suporta valores null, diferente de `Map.copyOf`)
- Adiciona Javadoc documentando o contrato de imutabilidade e propósito do `rawJson`

Closes #15
Closes #16

## Test plan
- [x] 109 testes passando (0 falhas)
- [x] Novos testes validam que `additionalMetrics().put()` lança `UnsupportedOperationException`
- [x] Novos testes validam que `rawJson` contém dados serializados do DTO original
- [x] Testes existentes continuam passando com `Collections.unmodifiableMap` (compatível com valores null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)